### PR TITLE
Add check to support custom mappings

### DIFF
--- a/plugin/change-inside-surroundings.vim
+++ b/plugin/change-inside-surroundings.vim
@@ -37,5 +37,11 @@ endfunction
 
 command! ChangeInsideSurrounding :call <sid>ChangeSurrounding("i")
 command! ChangeAroundSurrounding :call <sid>ChangeSurrounding("a")
-nmap <script> <silent> <unique> <Leader>ci :ChangeInsideSurrounding<CR>
-nmap <script> <silent> <unique> <Leader>cas :ChangeAroundSurrounding<CR>
+
+if !hasmapto(':ChangeInsideSurrounding<CR>')
+  nmap <script> <silent> <unique> <Leader>ci :ChangeInsideSurrounding<CR>
+endif
+
+if !hasmapto(':ChangeAroundSurrounding<CR>')
+  nmap <script> <silent> <unique> <Leader>cas :ChangeAroundSurrounding<CR>
+endif


### PR DESCRIPTION
I use this plugin ALL the time, especially when maintaining old projects. It speeds up complex text replacement without having to hunt down the surrounding bracket, quote, whatever... Thanks for creating this!

Because I use it fairly extensively, I wanted to be able to map it to something even faster than <leader>ci and <leader>cas

...so I added a quick check to see if the user has already created a mapping for the functions, and if not apply the original defaults. This way I don't wind up with two separate mappings for the same command.

I'll leave it up to you if this is something you'd like to include.

Thanks again.
